### PR TITLE
Add Writer affix on Writer classes to prevent using PHP7 reserved words

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ sudo: false
 
 php:
   - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
 
 before_script: composer install
 script: ./vendor/bin/phpunit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## dev-master
 
+- Enhancements
+    - PHP 7 compatibility ([#2](https://github.com/mneudert/junit-scribe/pull/2))
+
 - Backwards incompatible changes
     - Minimum required php version is now `>=5.6.0`
+    - Writer classes have been renamed to support PHP 7
 
 ## v0.1.0 (2014-06-21)
 

--- a/examples/jenkins.php
+++ b/examples/jenkins.php
@@ -3,7 +3,7 @@
 require_once '../vendor/autoload.php';
 
 use JUnitScribe\Document;
-use JUnitScribe\Writer\String as StringWriter;
+use JUnitScribe\Writer\StringWriter;
 
 $document = new Document();
 $document

--- a/src/Writer/FileWriter.php
+++ b/src/Writer/FileWriter.php
@@ -2,7 +2,7 @@
 
 namespace JUnitScribe\Writer;
 
-class File extends String
+class FileWriter extends StringWriter
 {
     /** @var string */
     protected $outputFilename;

--- a/src/Writer/StringWriter.php
+++ b/src/Writer/StringWriter.php
@@ -8,7 +8,7 @@ use JUnitScribe\Document\Node;
 use JUnitScribe\Document\ResultNode;
 use JUnitScribe\Document\SuiteNode;
 
-class String
+class StringWriter
 {
     const INDENTATION = '  ';
 

--- a/tests/Writer/FileWriterTest.php
+++ b/tests/Writer/FileWriterTest.php
@@ -3,10 +3,10 @@
 namespace JUnitScribeTest\Writer;
 
 use JUnitScribe\Document;
-use JUnitScribe\Writer\File as FileWriter;
+use JUnitScribe\Writer\FileWriter;
 use JUnitScribeTest\TestCase;
 
-class FileTest extends TestCase
+class FileWriterTest extends TestCase
 {
     public function testNeverSuccesfulWithoutDocument()
     {

--- a/tests/Writer/StringWriterTest.php
+++ b/tests/Writer/StringWriterTest.php
@@ -3,10 +3,10 @@
 namespace JUnitScribeTest\Writer;
 
 use JUnitScribe\Document;
-use JUnitScribe\Writer\String as StringWriter;
+use JUnitScribe\Writer\StringWriter;
 use JUnitScribeTest\TestCase;
 
-class StringTest extends TestCase
+class StringWriterTest extends TestCase
 {
     public function testDocumentOutput()
     {


### PR DESCRIPTION
As of PHP7, `String` is a reserved word (See #1).

This pull request extends current practice of using a Writer affix on Writer classes.